### PR TITLE
Add signedEncryptionScope to SAS signing string

### DIFF
--- a/Storage/Python/CreateDirectoryUserDelegationSAS.py
+++ b/Storage/Python/CreateDirectoryUserDelegationSAS.py
@@ -61,6 +61,7 @@ def createDirectoryScopedUserDelegationSAS():
     signedResource = "d" # d denotes directory scope
     signedDirectoryDepth = "1"
     signedSnapshotTime = ""
+    signedEncryptionScope = ""
     rscc = ""
     rscd = ""
     rsce = ""
@@ -86,6 +87,7 @@ def createDirectoryScopedUserDelegationSAS():
                     signedVersion + "\n" + \
                     signedResource + "\n" + \
                     signedSnapshotTime + "\n" + \
+                    signedEncryptionScope + "\n" + \
                     rscc + "\n" + \
                     rscd + "\n" + \
                     rsce + "\n" + \


### PR DESCRIPTION
According to [the code](https://github.com/Azure/azure-sdk-for-python/blob/a9ffe94dbcee69ecad78907d27d1722a4582c5e1/sdk/storage/azure-storage-blob/azure/storage/blob/_shared_access_signature.py#L286C14-L286C84), the signing string of SAS token need to add a `signedEncryptionScope` in it.